### PR TITLE
reuse single Redis connection in redis-logstash appender

### DIFF
--- a/lib/appenders/redis-logstash.js
+++ b/lib/appenders/redis-logstash.js
@@ -6,13 +6,14 @@ var os = require('os');
 
 function redisLogstashAppender (layout, config) {
     layout = layout || layouts.colouredLayout;
+    var client = redis.createClient(config.redisPort, config.redisHost).on('error', console.log);
+
     return function(loggingEvent) {
         var logObject = {}
         _.extend(logObject, config.baseLogFields)
         logObject.level = loggingEvent.level.levelStr
         logObject.hostname = os.hostname()
         if (loggingEvent.data.length > 0) {
-            var client = redis.createClient(config.redisPort, config.redisHost).on('error', console.log);
             var data = loggingEvent.data[0]
             if (typeof data == "string") {
                 logObject.message = data
@@ -20,9 +21,9 @@ function redisLogstashAppender (layout, config) {
             else if(typeof data == "object") {
                 _.extend(logObject, data)
             }
-
-            client.rpush(config.listName, JSON.stringify(logObject));
-            client.quit();
+            try {
+              client.rpush(config.listName, JSON.stringify(logObject));
+            } catch(e) {}
         }
     };
 }


### PR DESCRIPTION
Why this isn't in master is beyond me.

It's not quite done yet though. We're still leaking connections on logger.loglevel('message');
